### PR TITLE
Copy labels tables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,10 @@ pretty = true
 [tool.pytest.ini_options]
 minversion = "7.0"
 testpaths = ["tests"]
-filterwarnings = ["error"]
+filterwarnings = [
+    "error",
+    "ignore::FutureWarning", # TODO remove after zarr-python v3 
+]
 addopts = [
     "-vv",
     "--color=yes",

--- a/src/ngio/core/ngff_image.py
+++ b/src/ngio/core/ngff_image.py
@@ -300,6 +300,8 @@ class NgffImage:
         store: StoreLike,
         name: str,
         overwrite: bool = True,
+        copy_labels: bool = False,
+        copy_tables: bool = False,
         **kwargs: dict,
     ) -> "NgffImage":
         """Derive a new image from the current image.
@@ -308,6 +310,10 @@ class NgffImage:
             store (StoreLike): The store to create the new image in.
             name (str): The name of the new image.
             overwrite (bool): Whether to overwrite the image if it exists
+            copy_labels (bool): Whether to copy the labels from the current image
+                to the new image.
+            copy_tables (bool): Whether to copy the tables from the current image
+                to the new image.
             **kwargs: Additional keyword arguments.
                 Follow the same signature as `create_empty_ome_zarr_image`.
 
@@ -351,4 +357,31 @@ class NgffImage:
         create_empty_ome_zarr_image(
             **default_kwargs,
         )
-        return NgffImage(store=store)
+
+        new_image = NgffImage(store=store)
+
+        if copy_tables:
+            # TODO: to be refactored when the label location is changed in the spec
+            source_tables_group = self.tables._table_group
+
+            if source_tables_group is None:
+                raise ValueError("No tables group found in the source image.")
+
+            zarr.copy(source=source_tables_group, dest=new_image.group)
+
+            # Reopen the image to get the new tables
+            new_image = NgffImage(store=store)
+
+        if copy_labels:
+            # TODO: to be refactored when the label location is changed in the spec
+            source_labels_group = self.labels._label_group
+
+            if source_labels_group is None:
+                raise ValueError("No labels group found in the source image.")
+
+            zarr.copy(source=source_labels_group, dest=new_image.group)
+
+            # Reopen the image to get the new labels
+            new_image = NgffImage(store=store)
+
+        return new_image

--- a/src/ngio/core/ngff_image.py
+++ b/src/ngio/core/ngff_image.py
@@ -361,7 +361,7 @@ class NgffImage:
         new_image = NgffImage(store=store)
 
         if copy_tables:
-            # TODO: to be refactored when the label location is changed in the spec
+            # TODO: to be refactored when the table location is changed in the spec
             source_tables_group = self.tables._table_group
 
             if source_tables_group is None:

--- a/tests/core/test_ngff_image.py
+++ b/tests/core/test_ngff_image.py
@@ -38,3 +38,22 @@ class TestNgffImage:
         )
 
         new_ngff_image.update_omero_window(start_percentile=1.1, end_percentile=98.9)
+
+    def test_ngff_image_derive(self, ome_zarr_image_v04_path: Path) -> None:
+        from ngio.core.ngff_image import NgffImage
+
+        ngff_image = NgffImage(ome_zarr_image_v04_path)
+
+        for name, table_type in [("test_roi", "roi_table")]:
+            table = ngff_image.tables.new(name=name, table_type=table_type)
+            table.consolidate()
+
+        ngff_image.labels.derive("test_label")
+
+        new_path = ome_zarr_image_v04_path.parent / "new_ngff_image.zarr"
+        new_ngff_image = ngff_image.derive_new_image(
+            new_path, "new_image", overwrite=True, copy_labels=True, copy_tables=True
+        )
+
+        assert ngff_image.tables.list() == new_ngff_image.tables.list()
+        assert ngff_image.labels.list() == new_ngff_image.labels.list()


### PR DESCRIPTION
- Add kwargs to copy `labels` and `tables when deriving a new ngff image