### PR TITLE
Fix a few typos in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ NGIO is a Python library to streamline OME-Zarr image analysis workflows.
 **Main Goals:**
 
 - Abstract object base API for handling OME-Zarr files
-- Powefull iterators for processing data using common access patterns
+- Powerful iterators for processing data using common access patterns
 - Tight integration with [Fractal's Table Fractal](https://fractal-analytics-platform.github.io/fractal-tasks-core/tables/)
-- Validate OME-Zarr files
+- Validation of OME-Zarr files
 
 To get started, check out the [Getting Started](https://fractal-analytics-platform.github.io/ngio/getting-started/) guide. Or checkout our [Documentation](https://fractal-analytics-platform.github.io/ngio/)
 
@@ -33,7 +33,7 @@ To get started, check out the [Getting Started](https://fractal-analytics-platfo
 | Basic Iterators | Ongoing | End-September | Read and Write Iterators for common access patterns |
 | Base Documentation | ✅ | End-September | API Documentation and Examples |
 | Beta Ready Testing | ✅ | End-September | Beta Testing; Library is ready for testing, but the API is not stable |
-| Streaming from Fractal | Ongoing | December | Ngio can stream ome-zarr from fractal |
+| Streaming from Fractal | Ongoing | December | Ngio can stream OME-Zarr from fractal |
 | Mask Iterators | Ongoing | Early 2025 | Iterators over Masked Tables |
 | Advanced Iterators | Not started | mid-2025 | Iterators for advanced access patterns |
 | Parallel Iterators | Not started | mid-2025 | Concurrent Iterators for parallel read and write |

--- a/docs/getting_started/0_quickstart.md
+++ b/docs/getting_started/0_quickstart.md
@@ -77,13 +77,13 @@ Let's start by opening an OME-Zarr file and inspecting its contents.
 
 The `ome_zarr_container` is the core of ngio and the entry point to working with OME-Zarr images. It provides high-level access to the image metadata, images, labels, and tables.
 
-### What is not the OmeZarr Container?
+### What is the OmeZarr Container not?
 
-The `OmeZarr Container` object does allow use to interact with the image data directly. For that we need to interact with the `Image`, `Label`, and `Table` objects.
+The `OmeZarr Container` object does not allow the user to interact with the image data directly. For that, we need to use the `Image`, `Label`, and `Table` objects.
 
 ## Next Steps
 
-To lean how to work with the `OmeZarr Container` object, but also with the image, label, and table data, check out the following guides:
+To learn how to work with the `OmeZarr Container` object, but also with the image, label, and table data, check out the following guides:
 
 - [Ome-Zarr Container](1_ome_zarr_containers.md): An overview on how to user the Ome-Zarr Container object and how to create new images and labels.
 - [Images/Labels](2_images.md): To know more on how to work with image data.

--- a/docs/getting_started/1_ome_zarr_containers.md
+++ b/docs/getting_started/1_ome_zarr_containers.md
@@ -41,9 +41,9 @@ of labels, and tables available.
 - **Table management** allow to check which tables are available, access them, and create new tables
 - **Derive new OME-Zarr images** allow to create new images based on the original one, with the same or similar metadata
 
-### What is not the OmeZarr Container?
+### What is the OmeZarr Container not?
 
-The `OmeZarr Container` object does allow use to interact with the image data directly. For that we need to interact with the `Image`, `Label`, and `Table` objects.
+The `OmeZarr Container` object does not allow the user to interact with the image data directly. For that, we need to use the `Image`, `Label`, and `Table` objects.
 
 ### OME-Zarr Overview
 
@@ -119,7 +119,7 @@ new_ome_zarr_image = create_ome_zarr_from_array(
 
 ### Opening Remote OME-Zarr Containers
 
-You can use `ngio` to open remote OME-Zarr to open remote OME-Zarr containers. 
+You can use `ngio` to open remote OME-Zarr containers. 
 For publicly available OME-Zarr containers, you can just use the `open_ome_zarr_container` function with a URL.
 
 For example, to open a remote OME-Zarr container hosted on a github repository:

--- a/docs/getting_started/2_images.md
+++ b/docs/getting_started/2_images.md
@@ -195,4 +195,4 @@ Often, you might want to create a new label based on an existing image. You can 
 ```
 
 This will create a new label with the same dimensions as the original label (without channels) and compatible metadata.
-If you wanto to create a new label with slightly different metadata see [API Reference](https://fractal-analytics-platform.github.io/ngio/api/).
+If you want to create a new label with slightly different metadata see [API Reference](https://fractal-analytics-platform.github.io/ngio/api/).

--- a/docs/getting_started/3_tables.md
+++ b/docs/getting_started/3_tables.md
@@ -67,7 +67,7 @@ Ngio supports tree types of tables: `roi_table`, `feature_table`, and `mask_tabl
     ```
 
     This will return all the ROIs in the table.
-    Rois can be used to slice the image data:
+    ROIs can be used to slice the image data:
     ```pycon exec="true" source="console" session="get_started"
     >>> roi = roi_table.get("FOV_1")
     >>> roi_data = image.get_roi(roi)
@@ -123,7 +123,7 @@ Ngio supports tree types of tables: `roi_table`, `feature_table`, and `mask_tabl
     >>> masking_table.get(1)
     >>> print(masking_table.get(100)) # markdown-exec: hide
     ```
-    Rois can be used to slice the image data:
+    ROIs can be used to slice the image data:
     ```pycon exec="true" source="console" session="get_started"
     >>> roi = masking_table.get(100)
     >>> roi_data = image.get_roi(roi)
@@ -179,7 +179,7 @@ Ngio supports tree types of tables: `roi_table`, `feature_table`, and `mask_tabl
 
 #### Creating a Table
 
-Tables (diffently from Images and Labels) can be purely in memory objects, and don't need to be save on disk.
+Tables (differently from Images and Labels) can be purely in memory objects, and don't need to be saved on disk.
 
 === "Creating a ROI Table"
     ```pycon exec="true" source="console" session="get_started"
@@ -240,7 +240,7 @@ Tables (diffently from Images and Labels) can be purely in memory objects, and d
     >>> print(generic_table) # markdown-exec: hide
     ```
 
-    Or from a "AnnData" object:
+    Or from an "AnnData" object:
 
     ```pycon exec="true" source="console" session="get_started"
     >>> from ngio.tables import GenericTable


### PR DESCRIPTION
Just noticed a couple of typos when reading through the documentation 🙂 