### PR TITLE
Fix index validation

### DIFF
--- a/src/ngio/hcs/plate.py
+++ b/src/ngio/hcs/plate.py
@@ -687,6 +687,9 @@ class OmeZarrPlate:
         return self.tables_container.list_roi_tables()
 
     @overload
+    def get_table(self, name: str) -> Table: ...
+
+    @overload
     def get_table(self, name: str, check_type: None) -> Table: ...
 
     @overload
@@ -708,8 +711,19 @@ class OmeZarrPlate:
     ) -> GenericRoiTable: ...
 
     def get_table(self, name: str, check_type: TypedTable | None = None) -> Table:
-        """Get a table from the image."""
-        table = self.tables_container.get(name)
+        """Get a table from the image.
+
+        Args:
+            name (str): The name of the table.
+            check_type (TypedTable | None): The type of the table. If None, the
+                type is not checked. If a type is provided, the table must be of that
+                type.
+        """
+        if check_type is None:
+            table = self.tables_container.get(name, strict=False)
+            return table
+
+        table = self.tables_container.get(name, strict=True)
         match check_type:
             case "roi_table":
                 if not isinstance(table, RoiTable):
@@ -739,8 +753,6 @@ class OmeZarrPlate:
                         f"Table '{name}' is not a feature table. "
                         f"Found type: {table.type()}"
                     )
-                return table
-            case None:
                 return table
             case _:
                 raise NgioValueError(f"Unknown check_type: {check_type}")

--- a/src/ngio/images/ome_zarr_container.py
+++ b/src/ngio/images/ome_zarr_container.py
@@ -354,6 +354,9 @@ class OmeZarrContainer:
         return self.tables_container.list_roi_tables()
 
     @overload
+    def get_table(self, name: str) -> Table: ...
+
+    @overload
     def get_table(self, name: str, check_type: None) -> Table: ...
 
     @overload
@@ -375,8 +378,19 @@ class OmeZarrContainer:
     ) -> GenericRoiTable: ...
 
     def get_table(self, name: str, check_type: TypedTable | None = None) -> Table:
-        """Get a table from the image."""
-        table = self.tables_container.get(name)
+        """Get a table from the image.
+
+        Args:
+            name (str): The name of the table.
+            check_type (TypedTable | None): The type of the table. If None, the
+                type is not checked. If a type is provided, the table must be of that
+                type.
+        """
+        if check_type is None:
+            table = self.tables_container.get(name, strict=False)
+            return table
+
+        table = self.tables_container.get(name, strict=True)
         match check_type:
             case "roi_table":
                 if not isinstance(table, RoiTable):
@@ -406,8 +420,6 @@ class OmeZarrContainer:
                         f"Table '{name}' is not a feature table. "
                         f"Found type: {table.type()}"
                     )
-                return table
-            case None:
                 return table
             case _:
                 raise NgioValueError(f"Unknown check_type: {check_type}")

--- a/src/ngio/tables/backends/_utils.py
+++ b/src/ngio/tables/backends/_utils.py
@@ -53,6 +53,10 @@ def _validate_index_key_df(pandas_df: DataFrame, index_key: str | None) -> DataF
         pandas_df.index.name = index_key
         return pandas_df
 
+    if pandas_df.index.name is None:
+        pandas_df.index.name = index_key
+        return pandas_df
+
     raise NgioTableValidationError(f"Index key '{index_key}' is not found in DataFrame")
 
 

--- a/tests/unit/tables/test_backends_utils.py
+++ b/tests/unit/tables/test_backends_utils.py
@@ -118,6 +118,17 @@ def test_normalize_pandas_df(in_df, out_df, index_key, index_type, reset_index):
     )
 
 
+def test_normalize_pandas_df_index_none():
+    """Test the normalization of a pandas DataFrame."""
+    df = normalize_pandas_df(
+        sample_pandas_df_no_index(),
+        index_key="new_index_name",
+        index_type="str",
+        reset_index=False,
+    )
+    assert df.index.name == "new_index_name"
+
+
 def test_fail_normalize_pandas_df():
     """Test the normalization of a pandas DataFrame."""
     with pytest.raises(NgioTableValidationError):
@@ -130,7 +141,7 @@ def test_fail_normalize_pandas_df():
 
     with pytest.raises(NgioTableValidationError):
         normalize_pandas_df(
-            sample_pandas_df_no_index(),
+            sample_pandas_df_str_index(),
             index_key="not_exist",
             index_type="str",
             reset_index=False,


### PR DESCRIPTION

Reverts to <0.2.3 behavior of allowing index name to be none even when table requires an index.